### PR TITLE
GWT-POM: j2cl-java-util-currency-annotation-processor removed

### DIFF
--- a/gwt-pom.xml
+++ b/gwt-pom.xml
@@ -90,12 +90,6 @@
             <artifactId>gwt-java-util-Locale</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
-
-        <dependency>
-            <groupId>walkingkooka</groupId>
-            <artifactId>j2cl-java-util-currency-annotation-processor</artifactId>
-            <version>1.0-SNAPSHOT</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
- Mistake to add a/p to gwt-pom will cause failures